### PR TITLE
Update main.dart

### DIFF
--- a/第2章Flutter基础知识/Flutter主题/main.dart
+++ b/第2章Flutter基础知识/Flutter主题/main.dart
@@ -47,7 +47,7 @@ class MyHomePage extends StatelessWidget {
           child: Text(
             '带有背景颜色的文本组件',
             //获取主题的文本样式
-            style: Theme.of(context).textTheme.title,
+            style: Theme.of(context).textTheme.bodyText1,
           ),
         ),
       ),


### PR DESCRIPTION
'title' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline6. This feature was deprecated after v1.13.8..